### PR TITLE
Bump axios from 0.33.0 to 1.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "browserslist": "last 2 versions",
   "dependencies": {
     "agenda": "^5.0.0",
-    "axios": "0.33.0",
+    "axios": "1.18.1",
     "bcrypt": "^6.0.0",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "1.20.6",


### PR DESCRIPTION
## What
Bumps **axios** from `0.33.0` to `1.18.1` (current stable 1.x).

## Why
axios `0.x` is EOL and only ever received a backport for the SSRF CVE. Moving to the maintained `1.x` line gets full CVE coverage.

## Risk
Low. The only call site is [`webhookController.js`](controllers/webhookController.js#L48):

```js
await axios.post(webhookEndpoint, payload, { timeout: 5000 });
```

This signature is unchanged across the `0.x → 1.x` boundary. Verified with a runtime smoke test against a local HTTP server — JSON body and `content-type` delivered correctly under 1.18.1.

## Notes
- `package-lock.json` is gitignored in this repo, so only `package.json` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)