### PR TITLE
Fix pm2 process name to match live process (samply)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,9 +32,9 @@ if [ "$1" = "--first" ]; then
   echo "If pm2 isn't set to start on boot yet, run:  pm2 startup"
 else
   echo "==> Restarting pm2 process..."
-  pm2 restart samply-combined --update-env
+  pm2 restart samply --update-env
 fi
 
 echo ""
-echo "Done. Combined server runs on port 3000 (pm2 name: samply-combined)."
-echo "Status: pm2 status      Logs: pm2 logs samply-combined"
+echo "Done. Combined server runs on port 3000 (pm2 name: samply)."
+echo "Status: pm2 status      Logs: pm2 logs samply"

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -7,10 +7,10 @@
 module.exports = {
   apps: [
     {
-      // Distinct from the old PM2 entry "samply" so rollback is just
-      // `pm2 stop samply-combined && pm2 start samply`. After Stage 3c
-      // stability, you can rename to "samply" (or just leave as-is).
-      name: "samply-combined",
+      // Canonical PM2 process name. Must match the live process (and the
+      // `pm2 restart samply` in deploy.sh) so subsequent deploys and the
+      // boot-time resurrect target the same entry.
+      name: "samply",
       cwd: __dirname,
       script: "server.js",
       instances: 1,


### PR DESCRIPTION
## Problem
[deploy.sh:35](deploy.sh#L35) restarted `samply-combined` and [ecosystem.config.js:13](ecosystem.config.js#L13) declared that name, but the actual live (and boot-resurrected) pm2 process is **`samply`**.

Since `deploy.sh` runs with `set -e`, `pm2 restart samply-combined` errored on a non-existent process and **aborted the deploy after pull+build** — new code landed on disk but the old process kept serving, silently.

## Fix
Align both files to `samply`:
- `pm2 restart samply-combined` → `pm2 restart samply`
- `name: "samply-combined"` → `name: "samply"`
- refreshed the now-stale rollback comment

Verified: `bash -n deploy.sh` passes, `ecosystem.config.js` loads with `name === "samply"`, no `samply-combined` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)