### PR TITLE
Pin uuid to 9.0.1 (CommonJS) — 14.x is ESM-only, crashes prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "stripe": "^6.1.1",
     "timezone-picker": "^2.0.0-1",
     "uniqid": "^5.0.3",
-    "uuid": "14.0.0",
+    "uuid": "9.0.1",
     "validator": "13.15.22",
     "web-push": "^3.3.3"
   },


### PR DESCRIPTION
## Incident
Production (`samply`) crash-looped after deploy with `ERR_REQUIRE_ESM`: `require()` of ES Module `uuid/dist-node/index.js` from `controllers/projectController.js` is not supported.

## Cause
The dependabot bump to **uuid 14.0.0** (PR #39) is **ESM-only**. The codebase is CommonJS (`const uuid = require("uuid")`), and production runs **Node 20.11.1**, which cannot `require()` an ES module. The earlier smoke test passed only because it ran on Node 22, where `require(esm)` is supported — a false green.

## Fix
Pin **uuid 9.0.1**, the newest release that still ships a CommonJS build:
- no `type: "module"`; `main` points to the CJS `dist/index.js`
- same `uuid.v4()` API used in [projectController.js](controllers/projectController.js#L4)
- keeps the security fixes over the pre-existing 3.0.1

## Follow-up (not this PR)
Later, either migrate to Node >= 20.19 (supports `require(esm)`, unblocks uuid 14+) or convert the module to `import()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
