### PR TITLE
Add dependabot config: ignore uuid major bumps (ESM-only, breaks prod)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot configuration.
+#
+# Purpose of this file is narrow: keep the current "security updates only"
+# behavior (those are enabled in repo Settings and need no config), while
+# adding an ignore rule so Dependabot stops proposing uuid major bumps.
+#
+# WHY uuid is pinned to the 9.x line:
+#   uuid >= 10 trends toward ESM-only builds (14.x has no CommonJS entry).
+#   This app is CommonJS and production runs Node 20.11.1, which cannot
+#   require() an ES module (ERR_REQUIRE_ESM) — uuid 14 took prod down once.
+#   Revisit once production is on Node >= 20.19 (supports require(esm)).
+#
+# open-pull-requests-limit: 0 disables *version-update* PRs (so this file
+# does not start a flood of routine bumps). Dependabot *security* updates
+# are NOT subject to that limit and keep running; they honor the ignore
+# conditions below.
+
+version: 2
+updates:
+  # Express app (repo root)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      # Stay on uuid 9.x (last CommonJS line). Blocks 10.x and above for
+      # both version and security updates.
+      - dependency-name: "uuid"
+        versions: [">=10.0.0"]
+
+  # Next.js app
+  - package-ecosystem: "npm"
+    directory: "/nextapp"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` (the repo had none — current bumps are Dependabot **security updates**, which need no config).

## Why
Stops Dependabot from re-proposing **uuid >= 10**. uuid 10+ trends ESM-only (14.x ships no CommonJS build). This app is CommonJS and production runs **Node 20.11.1**, which cannot `require()` an ES module — uuid 14 caused a production outage (`ERR_REQUIRE_ESM`). Pinned to the last CJS line, 9.x.

## Behavior preserved
- `open-pull-requests-limit: 0` means **no new routine version-update PRs** — your current "security updates only" behavior is unchanged.
- Dependabot **security updates** are not subject to that limit; they keep running and honor the `ignore` condition, so a uuid-9.x security patch would still come through, but a jump to 10+ would not.
- Covers both `/` (Express app) and `/nextapp`.

## Revisit
Once production is on **Node >= 20.19** (supports `require(esm)`), this ignore can be relaxed. Tracked with the OS/Node migration.
