### PR TITLE
Fix "Every N days" schedules to roll across month boundaries

### DIFF
--- a/nextapp/app/createindividualnotification/route.ts
+++ b/nextapp/app/createindividualnotification/route.ts
@@ -5,7 +5,7 @@ import Project from "@/lib/models/project";
 import mongoose from "mongoose";
 import { nanoid } from "nanoid";
 import momentTz from "moment-timezone";
-import { scheduleBatch, expandCronBetween, BatchLimitError, type PendingNotificationDoc } from "@/lib/scheduling";
+import { scheduleBatch, expandScheduleBetween, BatchLimitError, type PendingNotificationDoc } from "@/lib/scheduling";
 import { sanitizeSurveyUrl } from "@/lib/urlValidation";
 
 const MAX_PROJECT_PENDING = 50_000;
@@ -69,22 +69,6 @@ function resolveUserStop(int_end: StoppingStrategy | undefined, userCreated: Dat
     }
   }
   return undefined;
-}
-
-// Anchor an "every N days" cron ("*/N" in the day-of-month field) to the
-// recipient's window start. cron-converter only honours a step when it is given
-// a RANGE: "7-31/7" yields [7,14,21,28], whereas the bare "7/7" collapses to just
-// [7]. So expand "*/N" into "<startDay>-31/N", using the day-of-month in the
-// schedule's timezone (a tz-naive Date.getDate() can be off by one near midnight).
-function patchStartDay(expr: string, start: string, timezone?: string): string {
-  if (!expr.includes("*/")) return expr;
-  const p = expr.split(" ");
-  if (p[3]?.startsWith("*/")) {
-    const step = p[3].slice(2);
-    const startDay = momentTz.tz(start, timezone || "UTC").date();
-    p[3] = `${startDay}-31/${step}`;
-  }
-  return p.join(" ");
 }
 
 export async function POST(req: NextRequest) {
@@ -174,7 +158,7 @@ export async function POST(req: NextRequest) {
           const gEnd = resolveUserStop(int_end, latestUser.created!, timezone) || int_endResolved;
           if (!gStart || !gEnd) continue;
           for (const iv of interval) {
-            const dates = expandCronBetween(patchStartDay(iv, gStart, timezone), gStart, gEnd, timezone);
+            const dates = expandScheduleBetween(iv, gStart, gEnd, timezone);
             const r = await scheduleBatch(dates.map((d) => ({
               ...baseDoc, scheduledFor: new Date(d), recipientGroupIds: [group], recipientUserIds: [],
             })));
@@ -186,7 +170,7 @@ export async function POST(req: NextRequest) {
             const uEnd = resolveUserStop(int_end, member.created!, timezone) || int_endResolved;
             if (!uStart || !uEnd) continue;
             for (const iv of interval) {
-              const dates = expandCronBetween(patchStartDay(iv, uStart, timezone), uStart, uEnd, timezone);
+              const dates = expandScheduleBetween(iv, uStart, uEnd, timezone);
               const r = await scheduleBatch(dates.map((d) => ({
                 ...baseDoc, scheduledFor: new Date(d), recipientUserIds: [member.id], recipientGroupIds: [],
               })));
@@ -203,7 +187,7 @@ export async function POST(req: NextRequest) {
         const uEnd = resolveUserStop(int_end, user.created!, timezone) || int_endResolved;
         if (!uStart || !uEnd) continue;
         for (const iv of interval) {
-          const dates = expandCronBetween(patchStartDay(iv, uStart, timezone), uStart, uEnd, timezone);
+          const dates = expandScheduleBetween(iv, uStart, uEnd, timezone);
           const r = await scheduleBatch(dates.map((d) => ({
             ...baseDoc, scheduledFor: new Date(d), recipientUserIds: [user.id], recipientGroupIds: [],
           })));

--- a/nextapp/app/createintervalnotification/route.ts
+++ b/nextapp/app/createintervalnotification/route.ts
@@ -6,7 +6,7 @@ import mongoose from "mongoose";
 import { nanoid } from "nanoid";
 import momentTz from "moment-timezone";
 import {
-  scheduleBatch, expandCronBetween, computeRandomWindowDocs,
+  scheduleBatch, expandScheduleBetween, computeRandomWindowDocs,
   BatchLimitError, type PendingNotificationDoc
 } from "@/lib/scheduling";
 import cronstrue from "cronstrue";
@@ -259,7 +259,7 @@ export async function POST(req: NextRequest) {
             const gEnd = resolveStop(int_end, latestUser.created, timezone) || int_endResolved;
             if (!gStart || !gEnd) continue;
             for (const iv of interval) {
-              const dates = expandCronBetween(patchStartDay(iv, gStart, timezone), gStart, gEnd, timezone);
+              const dates = expandScheduleBetween(iv, gStart, gEnd, timezone);
               const r = await scheduleBatch(dates.map((d) => ({
                 ...baseDoc, scheduledFor: new Date(d), recipientGroupIds: [group], recipientUserIds: [],
               })));
@@ -271,7 +271,7 @@ export async function POST(req: NextRequest) {
               const uEnd = resolveStop(int_end, member.created, timezone) || int_endResolved;
               if (!uStart || !uEnd) continue;
               for (const iv of interval) {
-                const dates = expandCronBetween(patchStartDay(iv, uStart, timezone), uStart, uEnd, timezone);
+                const dates = expandScheduleBetween(iv, uStart, uEnd, timezone);
                 const r = await scheduleBatch(dates.map((d) => ({
                   ...baseDoc, scheduledFor: new Date(d), recipientUserIds: [member.id], recipientGroupIds: [],
                 })));
@@ -289,7 +289,7 @@ export async function POST(req: NextRequest) {
           const uEnd = resolveStop(int_end, user.created, timezone) || int_endResolved;
           if (!uStart || !uEnd) continue;
           for (const iv of interval) {
-            const dates = expandCronBetween(patchStartDay(iv, uStart, timezone), uStart, uEnd, timezone);
+            const dates = expandScheduleBetween(iv, uStart, uEnd, timezone);
             const r = await scheduleBatch(dates.map((d) => ({
               ...baseDoc, scheduledFor: new Date(d), recipientUserIds: [user.id], recipientGroupIds: [],
             })));

--- a/nextapp/lib/scheduleForUser.ts
+++ b/nextapp/lib/scheduleForUser.ts
@@ -1,7 +1,7 @@
 import momentTz from "moment-timezone";
 import type mongoose from "mongoose";
 import {
-  scheduleBatch, expandCronBetween, computeRandomWindowDocs,
+  scheduleBatch, expandScheduleBetween, computeRandomWindowDocs,
 } from "./scheduling";
 
 export interface StoredConfig {
@@ -143,7 +143,7 @@ export async function scheduleForUser(
       const start = resolveStart(cfg, user.created, timezone);
       const stop = resolveStop(cfg, user.created, timezone);
       if (!start || !stop) continue;
-      const dates = expandCronBetween(patchStartDay(cfg.interval, start, timezone), start, stop, timezone);
+      const dates = expandScheduleBetween(cfg.interval, start, stop, timezone);
       const r = await scheduleBatch(
         dates.map((d) => ({ ...baseDoc, scheduledFor: new Date(d) }))
       );

--- a/nextapp/lib/scheduling.ts
+++ b/nextapp/lib/scheduling.ts
@@ -69,6 +69,87 @@ export function expandCronBetween(cronExpr: string, from: Date | string, to: Dat
   return dates;
 }
 
+// Parse a cron month field (1-12) into a Set of allowed months, or null for
+// "any month" ("*"). Supports comma lists, ranges (a-b) and steps (a-b/s, */s).
+// An unrecognised token yields null (treat as "any") rather than silently
+// dropping occurrences.
+function parseMonthField(field: string): Set<number> | null {
+  if (!field || field === "*") return null;
+  const set = new Set<number>();
+  for (const token of field.split(",")) {
+    const step = /^(\*|\d+(?:-\d+)?)\/(\d+)$/.exec(token);
+    if (step) {
+      const s = parseInt(step[2], 10);
+      let lo = 1, hi = 12;
+      if (step[1] !== "*") {
+        const r = step[1].split("-").map(Number);
+        lo = r[0]; hi = r.length > 1 ? r[1] : lo;
+      }
+      for (let v = lo; v <= hi; v += s) set.add(v);
+    } else if (/^\d+-\d+$/.test(token)) {
+      const [lo, hi] = token.split("-").map(Number);
+      for (let v = lo; v <= hi; v++) set.add(v);
+    } else if (/^\d+$/.test(token)) {
+      set.add(parseInt(token, 10));
+    } else {
+      return null;
+    }
+  }
+  return set.size ? set : null;
+}
+
+// Expand a repeating schedule between [from, to] into ISO timestamps.
+//
+// "Every N days" is emitted by the form as "*/N" in the cron DAY-OF-MONTH field.
+// A day-of-month field is inherently per-month and RESETS at every month
+// boundary, so expanding it via cron can only ever emit the same day-numbers
+// within each month — it can never step e.g. 29 Jul -> 1 Aug. That made
+// repeating "every N days" schedules silently stop at the end of the start
+// month (Samply issue: an interval + a stop date in a later month produced no
+// occurrences after the first month).
+//
+// This detects that interval shape and instead steps N *calendar* days from the
+// window start at the schedule's fixed time-of-day, so the cadence rolls
+// continuously across months. Stepping in the schedule timezone keeps the local
+// wall-clock time stable across DST. Any month restriction is still honoured.
+// Every other cron shape (specific days, weekly, every-day "*", minute
+// intervals, …) falls through to the generic cron expander unchanged.
+export function expandScheduleBetween(
+  cronExpr: string, from: Date | string, to: Date | string, timezone?: string
+): string[] {
+  const parts = cronExpr.trim().split(/\s+/);
+  const dom = parts.length === 6 ? parts[3] : null;
+  const stepMatch = dom ? /^\*\/(\d+)$/.exec(dom) : null;
+  const stepDays = stepMatch ? parseInt(stepMatch[1], 10) : 0;
+  const fixedTime = /^\d+$/.test(parts[0]) && /^\d+$/.test(parts[1]) && /^\d+$/.test(parts[2]);
+  const dowAny = parts[5] === "*";
+  // Only take the rolling-interval path for a clean "every N days at a fixed
+  // time, no weekday restriction". Anything else defers to cron.
+  if (!(stepDays >= 2 && fixedTime && dowAny)) {
+    return expandCronBetween(cronExpr, from, to, timezone);
+  }
+
+  const tz = timezone || "UTC";
+  const second = parseInt(parts[0], 10);
+  const minute = parseInt(parts[1], 10);
+  const hour = parseInt(parts[2], 10);
+  const months = parseMonthField(parts[4]);
+  const fromM = momentTz.tz(from, tz);
+  const toM = momentTz.tz(to, tz);
+  // Anchor at the schedule's time-of-day on the window-start day, then step.
+  const cur = fromM.clone().set({ hour, minute, second, millisecond: 0 });
+  const out: string[] = [];
+  let guard = 0;
+  while (cur.isSameOrBefore(toM) && guard < 100_000) {
+    guard++;
+    if (cur.isSameOrAfter(fromM) && (months === null || months.has(cur.month() + 1))) {
+      out.push(cur.toISOString());
+    }
+    cur.add(stepDays, "days");
+  }
+  return out;
+}
+
 function getNumberBetween(min: number, max: number): number {
   return Math.round(Math.random() * (max - min) + min);
 }

--- a/services/scheduleExpand.js
+++ b/services/scheduleExpand.js
@@ -1,0 +1,98 @@
+// Pure schedule-expansion helpers (no DB / model dependencies) so they can be
+// unit-tested in isolation. Mirrors nextapp/lib/scheduling.ts — keep in sync.
+const momentTz = require("moment-timezone");
+const Cron = require("cron-converter");
+
+function toFivePart(cronExpr) {
+  const parts = cronExpr.trim().split(/\s+/);
+  return parts.length >= 6 ? parts.slice(1).join(" ") : cronExpr;
+}
+
+// Expand a standard cron between [from, to] into ISO timestamps.
+function expandCronBetween(cronExpr, from, to, timezone) {
+  const fivePart = toFivePart(cronExpr);
+  const inst = new Cron({ timezone: timezone || "UTC" });
+  try {
+    inst.fromString(fivePart);
+  } catch (e) {
+    return [];
+  }
+  const endMs = new Date(to).getTime();
+  const schedule = inst.schedule(new Date(new Date(from).getTime() - 1));
+  const dates = [];
+  let next = schedule.next();
+  while (next && next.valueOf() <= endMs) {
+    dates.push(new Date(next.valueOf()).toISOString());
+    next = schedule.next();
+  }
+  return dates;
+}
+
+// Parse a cron month field (1-12) into a Set of allowed months, or null for
+// "any month" ("*"). Supports comma lists, ranges (a-b) and steps (a-b/s, */s).
+function parseMonthField(field) {
+  if (!field || field === "*") return null;
+  const set = new Set();
+  for (const token of field.split(",")) {
+    const step = /^(\*|\d+(?:-\d+)?)\/(\d+)$/.exec(token);
+    if (step) {
+      const s = parseInt(step[2], 10);
+      let lo = 1, hi = 12;
+      if (step[1] !== "*") {
+        const r = step[1].split("-").map(Number);
+        lo = r[0]; hi = r.length > 1 ? r[1] : lo;
+      }
+      for (let v = lo; v <= hi; v += s) set.add(v);
+    } else if (/^\d+-\d+$/.test(token)) {
+      const [lo, hi] = token.split("-").map(Number);
+      for (let v = lo; v <= hi; v++) set.add(v);
+    } else if (/^\d+$/.test(token)) {
+      set.add(parseInt(token, 10));
+    } else {
+      return null;
+    }
+  }
+  return set.size ? set : null;
+}
+
+// Expand a repeating schedule between [from, to] into ISO timestamps.
+//
+// "Every N days" is emitted as "*/N" in the cron DAY-OF-MONTH field, which is
+// per-month and resets at every month boundary — so a cron expansion can never
+// step e.g. 29 Jul -> 1 Aug and repeating schedules silently stopped at the end
+// of the start month. Detect that shape and instead step N calendar days from
+// the window start at the schedule's fixed time-of-day (in the schedule
+// timezone, so the local wall-clock time is stable across DST). Any month
+// restriction is honoured. Everything else defers to the cron expander.
+function expandScheduleBetween(cronExpr, from, to, timezone) {
+  const parts = cronExpr.trim().split(/\s+/);
+  const dom = parts.length === 6 ? parts[3] : null;
+  const stepMatch = dom ? /^\*\/(\d+)$/.exec(dom) : null;
+  const stepDays = stepMatch ? parseInt(stepMatch[1], 10) : 0;
+  const fixedTime = /^\d+$/.test(parts[0]) && /^\d+$/.test(parts[1]) && /^\d+$/.test(parts[2]);
+  const dowAny = parts[5] === "*";
+  if (!(stepDays >= 2 && fixedTime && dowAny)) {
+    return expandCronBetween(cronExpr, from, to, timezone);
+  }
+
+  const tz = timezone || "UTC";
+  const second = parseInt(parts[0], 10);
+  const minute = parseInt(parts[1], 10);
+  const hour = parseInt(parts[2], 10);
+  const months = parseMonthField(parts[4]);
+  const fromM = momentTz.tz(from, tz);
+  const toM = momentTz.tz(to, tz);
+  const cur = fromM.clone().set({ hour, minute, second, millisecond: 0 });
+  const out = [];
+  let guard = 0;
+  while (cur.isSameOrBefore(toM) && guard < 100000) {
+    guard++;
+    if (cur.isSameOrAfter(fromM) && (months === null || months.has(cur.month() + 1))) {
+      out.push(cur.toISOString());
+    }
+    cur.add(stepDays, "days");
+  }
+  return out;
+}
+
+module.exports = { toFivePart, expandCronBetween, parseMonthField, expandScheduleBetween };

--- a/services/scheduleForUser.js
+++ b/services/scheduleForUser.js
@@ -1,30 +1,7 @@
 const momentTz = require("moment-timezone");
 const Cron = require("cron-converter");
 const { scheduleBatch } = require("./notificationScheduler");
-
-function toFivePart(cronExpr) {
-  const parts = cronExpr.trim().split(/\s+/);
-  return parts.length >= 6 ? parts.slice(1).join(" ") : cronExpr;
-}
-
-function expandCronBetween(cronExpr, from, to, timezone) {
-  const fivePart = toFivePart(cronExpr);
-  const inst = new Cron({ timezone: timezone || "UTC" });
-  try {
-    inst.fromString(fivePart);
-  } catch (e) {
-    return [];
-  }
-  const endMs = new Date(to).getTime();
-  const schedule = inst.schedule(new Date(new Date(from).getTime() - 1));
-  const dates = [];
-  let next = schedule.next();
-  while (next && next.valueOf() <= endMs) {
-    dates.push(new Date(next.valueOf()).toISOString());
-    next = schedule.next();
-  }
-  return dates;
-}
+const { expandScheduleBetween, expandCronBetween, toFivePart } = require("./scheduleExpand");
 
 function getNumberBetween(min, max) {
   return Math.round(Math.random() * (max - min) + min);
@@ -212,7 +189,7 @@ async function scheduleForUser(projectOid, user, groupId, configs) {
       const start = resolveStart(cfg, user.created, timezone);
       const stop = resolveStop(cfg, user.created, timezone);
       if (!start || !stop) continue;
-      const dates = expandCronBetween(patchStartDay(cfg.interval, start, timezone), start, stop, timezone);
+      const dates = expandScheduleBetween(cfg.interval, start, stop, timezone);
       const r = await scheduleBatch(
         dates.map((d) => ({ ...baseDoc, scheduledFor: new Date(d) }))
       );


### PR DESCRIPTION
## The bug
A researcher's "every 3 days for 29 days" schedule (registered 17 Jul) produced only **17, 20, 23, 26, 29 Jul** and nothing in August.

"Every N days" was emitted as `*/N` in the cron **day-of-month** field and anchored to `<startDay>-31/N` (`patchStartDay`). A day-of-month field is per-month and **resets at every month boundary**, so it can only ever emit the same day-numbers within each month — it can never step 29 Jul → 1 Aug. The stop date (correctly computed as 15 Aug) then filtered out August's reset days (17–29 Aug, all after the stop), leaving 5 July occurrences.

## The fix
New `expandScheduleBetween(cron, from, to, tz)`:
- Detects the "every N days at a fixed time, no weekday restriction" shape (`*/N` in day-of-month).
- Generates occurrences by **stepping N calendar days from the window start** at the schedule's time-of-day, in the schedule timezone — so the cadence rolls continuously across months and **local wall-clock time stays stable across DST**.
- Honours any month restriction.
- **Everything else** (specific days, weekly, every-day `*`, minute intervals like `*/15` in the minute field) falls through to the existing cron expander unchanged.

## Scope — all live paths
The current dashboard posts to the nextapp routes; the mobile app and dashboard never hit the legacy `jobController` Agenda path, so it's left untouched.
- `nextapp/lib/scheduling.ts` — new `expandScheduleBetween` (+ `parseMonthField`)
- `nextapp/app/createintervalnotification/route.ts` — non-registration schedules
- `nextapp/app/createindividualnotification/route.ts` — **registration-based schedules (the reported case)**
- `nextapp/lib/scheduleForUser.ts` — nextapp enrollment (late joiners)
- `services/scheduleForUser.js` — Express enrollment (late joiners)
- `services/scheduleExpand.js` — **new**: pure, DB-free helpers extracted so they're unit-testable

## Verification
Unit tests against the extracted logic (all pass):
- **User scenario** → 10 occurrences, 17 Jul → 13 Aug (crosses the boundary) ✓
- **DST** (Berlin fall-back) → local 17:00 preserved; UTC instant shifts 15:00Z → 16:00Z ✓
- **Month restriction** (July only) → August filtered ✓
- **Daily `*`** and **minute-interval `*/15`** → correctly defer to cron ✓
- **Leap year** Feb→Mar, and start-time-of-day already passed ✓
- Full `next build` type-checks and compiles cleanly.

## ⚠️ Existing broken schedules are not retroactively fixed
This corrects schedules created **after** deploy (and new enrollments). Notifications already queued under the old logic remain as-is. The reporting researcher should **delete and recreate** the affected schedule after this ships. If wider backfill is wanted, we can add a one-off regeneration step — flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
