### PR TITLE
Add content editing for existing schedules (v1)

### DIFF
--- a/nextapp/app/dashboard/[studyId]/schedule/[notificationId]/edit/EditScheduleForm.tsx
+++ b/nextapp/app/dashboard/[studyId]/schedule/[notificationId]/edit/EditScheduleForm.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState } from "react";
+import { useFormStatus } from "react-dom";
+import { useT } from "@/app/components/TranslationProvider";
+import { updateScheduleContentAction } from "@/app/scheduled/actions";
+
+interface ReminderState { title: string; message: string; days: number; hours: number; minutes: number }
+
+interface Props {
+  studyId: string;
+  notificationId: string;
+  initial: {
+    title: string;
+    message: string;
+    url?: string;
+    expireIn?: number | null;
+    reminders?: Array<{ title: string; message: string; time: number }>;
+  };
+}
+
+const FIELD: React.CSSProperties = {
+  fontFamily: "var(--font-mono)", fontSize: "1.2rem", padding: "0.8rem 1.2rem",
+  borderRadius: "0.6rem", border: "1px solid var(--ink-20)", background: "var(--paper)",
+  color: "var(--ink)", outline: "none", width: "100%", boxSizing: "border-box",
+};
+const FIELD_SM: React.CSSProperties = {
+  fontFamily: "var(--font-mono)", fontSize: "1.2rem", padding: "0.6rem 0.8rem",
+  borderRadius: "0.6rem", border: "1px solid var(--ink-20)", background: "var(--paper)",
+  color: "var(--ink)", outline: "none", width: "6rem", textAlign: "center", boxSizing: "border-box",
+};
+const LABEL: React.CSSProperties = {
+  fontFamily: "var(--font-mono)", fontSize: "0.95rem", letterSpacing: ".08em",
+  textTransform: "uppercase", color: "var(--ink-40)", display: "block", marginBottom: "0.5rem",
+};
+const INLINE_LABEL: React.CSSProperties = { fontFamily: "var(--font-mono)", fontSize: "1.1rem", color: "var(--ink-60)" };
+const CARD: React.CSSProperties = {
+  background: "var(--surface)", border: "1px solid var(--ink-10)", borderRadius: "1rem",
+  padding: "1.8rem 2rem", display: "flex", flexDirection: "column", gap: "1.2rem",
+};
+const CARD_TITLE: React.CSSProperties = {
+  fontFamily: "var(--font-mono)", fontSize: "1.05rem", letterSpacing: ".08em",
+  textTransform: "uppercase", color: "var(--ink-60)", margin: 0,
+};
+
+function msToDHM(ms: number): { days: number; hours: number; minutes: number } {
+  const totalMin = Math.max(0, Math.round(ms / 60000));
+  return { days: Math.floor(totalMin / 1440), hours: Math.floor((totalMin % 1440) / 60), minutes: totalMin % 60 };
+}
+function dhmToMs(days: number, hours: number, minutes: number): number {
+  return (days * 24 * 60 + hours * 60 + minutes) * 60000;
+}
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" disabled={pending}
+      style={{
+        fontFamily: "var(--font-mono)", fontSize: "1.15rem", letterSpacing: ".04em",
+        padding: "0.9rem 2rem", borderRadius: "9999px", border: "1px solid var(--coral)",
+        background: "var(--coral)", color: "var(--paper)", cursor: pending ? "wait" : "pointer",
+        opacity: pending ? 0.7 : 1,
+      }}>
+      {pending ? "…" : label}
+    </button>
+  );
+}
+
+export default function EditScheduleForm({ studyId, notificationId, initial }: Props) {
+  const { t } = useT();
+  const action = updateScheduleContentAction.bind(null, studyId, notificationId);
+
+  const [title, setTitle] = useState(initial.title ?? "");
+  const [message, setMessage] = useState(initial.message ?? "");
+  const [url, setUrl] = useState(initial.url ?? "https://");
+
+  const initExpire = initial.expireIn && initial.expireIn > 0 ? msToDHM(initial.expireIn) : null;
+  const [expireType, setExpireType] = useState<"no" | "yes">(initExpire ? "yes" : "no");
+  const [expireDays, setExpireDays] = useState(initExpire?.days ?? 0);
+  const [expireHours, setExpireHours] = useState(initExpire?.hours ?? 0);
+  const [expireMinutes, setExpireMinutes] = useState(initExpire?.minutes ?? 0);
+
+  const initReminders: ReminderState[] = (initial.reminders ?? []).map((r) => ({
+    title: r.title ?? "", message: r.message ?? "", ...msToDHM(r.time ?? 0),
+  }));
+  const [reminderType, setReminderType] = useState<"no" | "yes">(initReminders.length ? "yes" : "no");
+  const [reminders, setReminders] = useState<ReminderState[]>(
+    initReminders.length ? initReminders : [{ title: "", message: "", days: 0, hours: 0, minutes: 0 }],
+  );
+
+  const expireHidden = expireType === "yes" ? String(dhmToMs(expireDays, expireHours, expireMinutes)) : "";
+  const remindersHidden = JSON.stringify(
+    reminderType === "yes"
+      ? reminders.map((r) => ({ title: r.title, message: r.message, time: dhmToMs(r.days, r.hours, r.minutes) }))
+      : [],
+  );
+
+  return (
+    <form action={action} style={{ display: "flex", flexDirection: "column", gap: "1.6rem" }}>
+      {/* Content */}
+      <div style={CARD}>
+        <div>
+          <label style={LABEL}>{t("notificationForm.labelTitle")}</label>
+          <input name="title" style={FIELD} type="text" value={title} onChange={(e) => setTitle(e.target.value)} required />
+        </div>
+        <div>
+          <label style={LABEL}>{t("notificationForm.labelMessage")}</label>
+          <input name="message" style={FIELD} type="text" value={message} onChange={(e) => setMessage(e.target.value)} required />
+        </div>
+        <div>
+          <label style={LABEL}>{t("notificationForm.labelWebLink")}</label>
+          <input name="url" style={FIELD} type="text" value={url} onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://your-survey.com/?id=%SAMPLY_ID%" />
+        </div>
+      </div>
+
+      {/* Link expiry */}
+      <div style={CARD}>
+        <p style={CARD_TITLE}>{t("notificationForm.cardExpiry")}</p>
+        <div style={{ display: "flex", gap: "0.8rem" }}>
+          {(["no", "yes"] as const).map((v) => (
+            <button key={v} type="button" onClick={() => setExpireType(v)}
+              style={{
+                fontFamily: "var(--font-mono)", fontSize: "1.1rem", padding: "0.6rem 1.2rem",
+                borderRadius: "9999px", cursor: "pointer",
+                border: expireType === v ? "1px solid var(--coral)" : "1px solid var(--ink-20)",
+                background: expireType === v ? "rgba(214,90,48,.08)" : "var(--paper)",
+                color: expireType === v ? "var(--coral)" : "var(--ink-60)",
+              }}>
+              {v === "no" ? t("notificationForm.doesNotExpire") : t("notificationForm.expiresAfter")}
+            </button>
+          ))}
+        </div>
+        {expireType === "yes" && (
+          <div style={{ display: "flex", alignItems: "center", gap: "0.8rem" }}>
+            <input type="number" min={0} value={expireDays} style={FIELD_SM} onChange={(e) => setExpireDays(Number(e.target.value))} />
+            <span style={INLINE_LABEL}>d</span>
+            <input type="number" min={0} value={expireHours} style={FIELD_SM} onChange={(e) => setExpireHours(Number(e.target.value))} />
+            <span style={INLINE_LABEL}>h</span>
+            <input type="number" min={0} value={expireMinutes} style={FIELD_SM} onChange={(e) => setExpireMinutes(Number(e.target.value))} />
+            <span style={INLINE_LABEL}>m</span>
+          </div>
+        )}
+      </div>
+
+      {/* Reminders */}
+      <div style={CARD}>
+        <p style={CARD_TITLE}>{t("notificationForm.cardReminders")}</p>
+        <div style={{ display: "flex", gap: "0.8rem" }}>
+          {(["no", "yes"] as const).map((v) => (
+            <button key={v} type="button" onClick={() => setReminderType(v)}
+              style={{
+                fontFamily: "var(--font-mono)", fontSize: "1.1rem", padding: "0.6rem 1.2rem",
+                borderRadius: "9999px", cursor: "pointer",
+                border: reminderType === v ? "1px solid var(--coral)" : "1px solid var(--ink-20)",
+                background: reminderType === v ? "rgba(214,90,48,.08)" : "var(--paper)",
+                color: reminderType === v ? "var(--coral)" : "var(--ink-60)",
+              }}>
+              {v === "no" ? t("notificationForm.noReminders") : t("notificationForm.addReminders")}
+            </button>
+          ))}
+        </div>
+        {reminderType === "yes" && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            <p style={{ fontFamily: "var(--font-mono)", fontSize: "1.1rem", color: "var(--ink-60)", margin: 0, lineHeight: 1.6 }}>
+              {t("notificationForm.reminderHint")}
+            </p>
+            {reminders.map((r, i) => (
+              <div key={i} style={{ background: "var(--paper)", border: "1px solid var(--ink-10)", borderRadius: "0.6rem", padding: "1.2rem 1.4rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+                <div style={{ display: "flex", gap: "1rem" }}>
+                  <div style={{ flex: 1 }}>
+                    <label style={LABEL}>{t("notificationForm.labelTitle")}</label>
+                    <input style={FIELD} type="text" value={r.title}
+                      onChange={(e) => setReminders((p) => p.map((x, j) => j === i ? { ...x, title: e.target.value } : x))} />
+                  </div>
+                  <div style={{ flex: 1 }}>
+                    <label style={LABEL}>{t("notificationForm.labelMessage")}</label>
+                    <input style={FIELD} type="text" value={r.message}
+                      onChange={(e) => setReminders((p) => p.map((x, j) => j === i ? { ...x, message: e.target.value } : x))} />
+                  </div>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: "0.8rem" }}>
+                  <span style={INLINE_LABEL}>{t("notificationForm.sendAfter")}</span>
+                  <input type="number" min={0} value={r.days} style={FIELD_SM}
+                    onChange={(e) => setReminders((p) => p.map((x, j) => j === i ? { ...x, days: Number(e.target.value) } : x))} />
+                  <span style={INLINE_LABEL}>d</span>
+                  <input type="number" min={0} value={r.hours} style={FIELD_SM}
+                    onChange={(e) => setReminders((p) => p.map((x, j) => j === i ? { ...x, hours: Number(e.target.value) } : x))} />
+                  <span style={INLINE_LABEL}>h</span>
+                  <input type="number" min={0} value={r.minutes} style={FIELD_SM}
+                    onChange={(e) => setReminders((p) => p.map((x, j) => j === i ? { ...x, minutes: Number(e.target.value) } : x))} />
+                  <span style={INLINE_LABEL}>m</span>
+                  {reminders.length > 1 && (
+                    <button type="button" onClick={() => setReminders((p) => p.filter((_, j) => j !== i))}
+                      style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: "1rem", background: "none", border: "none", color: "var(--coral)", cursor: "pointer", opacity: 0.75 }}>
+                      remove
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+            <button type="button" onClick={() => setReminders((p) => [...p, { title: "", message: "", days: 0, hours: 0, minutes: 0 }])}
+              style={{ alignSelf: "flex-start", fontFamily: "var(--font-mono)", fontSize: "1.1rem", background: "none", border: "none", color: "var(--coral)", cursor: "pointer", padding: 0 }}>
+              + {t("notificationForm.addReminder")}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Serialized state for the server action */}
+      <input type="hidden" name="expireIn" value={expireHidden} />
+      <input type="hidden" name="reminders" value={remindersHidden} />
+
+      <div style={{ display: "flex", alignItems: "center", gap: "1.4rem" }}>
+        <SubmitButton label="Save changes" />
+        <a href={`/scheduled/${studyId}?notificationId=${notificationId}`}
+          style={{ fontFamily: "var(--font-mono)", fontSize: "1.1rem", color: "var(--ink-40)", textDecoration: "none" }}>
+          cancel
+        </a>
+      </div>
+    </form>
+  );
+}

--- a/nextapp/app/dashboard/[studyId]/schedule/[notificationId]/edit/page.tsx
+++ b/nextapp/app/dashboard/[studyId]/schedule/[notificationId]/edit/page.tsx
@@ -1,0 +1,68 @@
+import { redirect, notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { fetchProjectById } from "@/lib/data/projects";
+import { fetchScheduledNotifications } from "@/lib/data/scheduled";
+import EditScheduleForm from "./EditScheduleForm";
+
+interface Props {
+  params: Promise<{ studyId: string; notificationId: string }>;
+}
+
+export default async function EditSchedulePage({ params }: Props) {
+  const { studyId, notificationId } = await params;
+  const session = await auth();
+  if (!session || session.user.level <= 10) redirect("/login");
+
+  // fetchProjectById returns null when the user has no access — same guard the create page uses.
+  const project = await fetchProjectById(studyId, session.user.id, session.user.level > 100);
+  if (!project) notFound();
+
+  const configs = await fetchScheduledNotifications(studyId);
+  const config = configs.find((n) => n.id === notificationId);
+  if (!config) notFound();
+
+  const cadence = config.readable?.interval || config.readable?.from || config.name || "this schedule";
+
+  return (
+    <div className="flex flex-col gap-[2.8rem]">
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "1.6rem" }}>
+        <div>
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: "1rem", letterSpacing: ".16em", textTransform: "uppercase", color: "var(--ink-40)", marginBottom: "0.6rem" }}>
+            edit schedule
+          </div>
+          <div className="font-[family-name:var(--font-display)] font-bold"
+            style={{ fontSize: "2.8rem", letterSpacing: "-0.02em", lineHeight: 1 }}>
+            {config.title || "Untitled schedule"}
+          </div>
+        </div>
+        <a href={`/scheduled/${studyId}?notificationId=${notificationId}`}
+          style={{ fontFamily: "var(--font-mono)", fontSize: "1.1rem", letterSpacing: ".06em", color: "var(--ink-60)", textDecoration: "none", padding: "0.8rem 1.6rem", border: "1px solid var(--ink-20)", borderRadius: "9999px", flexShrink: 0, marginTop: "0.4rem" }}
+          className="hover:opacity-70 transition-opacity">
+          back to queue
+        </a>
+      </div>
+
+      {/* Read-only context + scope note */}
+      <div style={{ background: "rgba(214,90,48,.06)", border: "1px solid rgba(214,90,48,.2)", borderRadius: "0.8rem", padding: "1.2rem 1.6rem" }}>
+        <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "1.15rem", color: "var(--ink-60)", lineHeight: 1.6 }}>
+          Editing the content of <strong style={{ color: "var(--ink)" }}>{cadence}</strong>. Timing and
+          recipients can&rsquo;t be changed here yet — only the message content, link, expiry and
+          reminders below. Changes apply to notifications that haven&rsquo;t been sent yet; anything
+          already delivered is unaffected.
+        </p>
+      </div>
+
+      <EditScheduleForm
+        studyId={studyId}
+        notificationId={notificationId}
+        initial={{
+          title: config.title ?? "",
+          message: config.message ?? "",
+          url: config.url,
+          expireIn: config.expireIn ?? null,
+          reminders: config.reminders,
+        }}
+      />
+    </div>
+  );
+}

--- a/nextapp/app/dashboard/[studyId]/schedule/page.tsx
+++ b/nextapp/app/dashboard/[studyId]/schedule/page.tsx
@@ -148,11 +148,18 @@ function NotifCard({ n, studyId, index, deleteAction, t }: { n: NotificationConf
       {/* Footer */}
       <div style={{ height: "0.1rem", backgroundImage: "radial-gradient(circle, var(--ink-40) 1px, transparent 1.2px)", backgroundSize: "0.8rem 0.1rem", backgroundRepeat: "repeat-x", opacity: 0.3 }} />
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "1.4rem" }}>
         <a href={`/scheduled/${studyId}?notificationId=${n.id}`}
           style={{ fontFamily: "var(--font-mono)", fontSize: "1.1rem", color: "var(--ink-60)", textDecoration: "none", letterSpacing: ".04em" }}
           className="hover:opacity-70 transition-opacity">
           {t("schedule.viewQueueCard")}
         </a>
+        <a href={`/dashboard/${studyId}/schedule/${n.id}/edit`}
+          style={{ fontFamily: "var(--font-mono)", fontSize: "1.1rem", color: "var(--ink-60)", textDecoration: "none", letterSpacing: ".04em" }}
+          className="hover:opacity-70 transition-opacity">
+          edit
+        </a>
+        </div>
         <DeleteScheduleButton
           action={deleteAction}
           label={t("schedule.delete")}

--- a/nextapp/app/scheduled/[id]/page.tsx
+++ b/nextapp/app/scheduled/[id]/page.tsx
@@ -350,16 +350,30 @@ export default async function ScheduledJobsPage({ params, searchParams }: Props)
             {t("scheduled.breadcrumb")}
           </a>
           {deleteScheduleAction && (
-            <DeleteScheduleButton
-              action={deleteScheduleAction}
-              label={t("scheduled.deleteSchedule")}
-              style={{
-                fontFamily: "var(--font-mono)", fontSize: "1rem", letterSpacing: ".04em",
-                padding: "0.5rem 1.2rem", borderRadius: "9999px",
-                border: "1px solid rgba(214,90,48,.35)", background: "rgba(214,90,48,.06)",
-                color: "var(--coral)", cursor: "pointer",
-              }}
-            />
+            <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+              <a
+                href={`/dashboard/${studyId}/schedule/${notificationId!}/edit`}
+                style={{
+                  fontFamily: "var(--font-mono)", fontSize: "1rem", letterSpacing: ".04em",
+                  padding: "0.5rem 1.2rem", borderRadius: "9999px",
+                  border: "1px solid var(--ink-20)", background: "var(--paper)",
+                  color: "var(--ink-60)", textDecoration: "none",
+                }}
+                className="hover:text-[var(--ink)] transition-colors"
+              >
+                edit schedule
+              </a>
+              <DeleteScheduleButton
+                action={deleteScheduleAction}
+                label={t("scheduled.deleteSchedule")}
+                style={{
+                  fontFamily: "var(--font-mono)", fontSize: "1rem", letterSpacing: ".04em",
+                  padding: "0.5rem 1.2rem", borderRadius: "9999px",
+                  border: "1px solid rgba(214,90,48,.35)", background: "rgba(214,90,48,.06)",
+                  color: "var(--coral)", cursor: "pointer",
+                }}
+              />
+            </div>
           )}
         </div>
 

--- a/nextapp/app/scheduled/actions.ts
+++ b/nextapp/app/scheduled/actions.ts
@@ -6,6 +6,7 @@ import connectDB from "@/lib/db";
 import Project from "@/lib/models/project";
 import AgendaJob from "@/lib/models/agendaJob";
 import PendingNotification from "@/lib/models/pendingNotification";
+import { sanitizeSurveyUrl } from "@/lib/urlValidation";
 import mongoose from "mongoose";
 import type { Session } from "next-auth";
 
@@ -165,4 +166,81 @@ export async function bulkDeletePendingNotificationsAction(
     });
   }
   redirect(safeReturnUrl(returnPath, `/scheduled/${studyId}`));
+}
+
+interface ReminderInput { title: string; message: string; time: number }
+
+// Edit the CONTENT of an existing schedule (title / message / URL / link expiry /
+// reminders) in place — leaving its cadence, recipients and history untouched.
+// The config's content is copied onto each occurrence at create time, so we must
+// update both the config (in Project.notifications) and the still-future,
+// unsent, non-reminder occurrences. Sent/processing/past occurrences and
+// already-materialised reminder occurrences are deliberately left as-is.
+// Reminders live only on the config and are materialised at send time, so no
+// occurrence backfill is needed for them.
+export async function updateScheduleContentAction(
+  studyId: string,
+  notificationId: string,
+  formData: FormData,
+) {
+  await requireProjectAccess(studyId);
+  const oid = new mongoose.Types.ObjectId(studyId);
+
+  const title = ((formData.get("title") as string) ?? "").trim();
+  const message = ((formData.get("message") as string) ?? "").trim();
+  const url = sanitizeSurveyUrl(formData.get("url") as string);
+
+  const expireRaw = (formData.get("expireIn") as string) ?? "";
+  const expireNum = expireRaw ? Number(expireRaw) : NaN;
+  const expireIn = Number.isFinite(expireNum) && expireNum > 0 ? expireNum : null;
+
+  let reminders: ReminderInput[] = [];
+  try {
+    const parsed = JSON.parse((formData.get("reminders") as string) || "[]");
+    if (Array.isArray(parsed)) {
+      reminders = parsed
+        .filter((r) => r && typeof r === "object")
+        .map((r) => ({
+          title: String(r.title ?? ""),
+          message: String(r.message ?? ""),
+          time: Number.isFinite(Number(r.time)) ? Number(r.time) : 0,
+        }));
+    }
+  } catch {
+    reminders = [];
+  }
+
+  // Title and message are required — bail back to the queue on invalid input.
+  if (!title || !message) redirect(returnUrl(studyId, notificationId));
+
+  await Promise.all([
+    // Update the config element(s) sharing this id (multi-cron submissions share one id).
+    Project.updateOne(
+      { _id: oid, "notifications.id": notificationId },
+      {
+        $set: {
+          "notifications.$[c].title": title,
+          "notifications.$[c].message": message,
+          "notifications.$[c].url": url,
+          "notifications.$[c].expireIn": expireIn,
+          "notifications.$[c].reminders": reminders,
+        },
+      },
+      { arrayFilters: [{ "c.id": notificationId }] },
+    ),
+    // Update only future, unsent, non-reminder occurrences (race-safe: the send
+    // worker claims status:"pending" and flips to "processing" atomically).
+    PendingNotification.updateMany(
+      {
+        projectId: oid,
+        notificationConfigId: notificationId,
+        status: "pending",
+        scheduledFor: { $gt: new Date() },
+        isReminder: { $ne: true },
+      },
+      { $set: { title, message, url, expireIn } },
+    ),
+  ]);
+
+  redirect(returnUrl(studyId, notificationId));
 }

--- a/nextapp/app/scheduled/page.tsx
+++ b/nextapp/app/scheduled/page.tsx
@@ -136,6 +136,19 @@ function NotifRow({
         >
           view queue →
         </a>
+        <a
+          href={`/dashboard/${projectId}/schedule/${n.id}/edit`}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "1rem",
+            letterSpacing: ".04em",
+            color: "var(--ink-60)",
+            textDecoration: "none",
+          }}
+          className="hover:text-[var(--ink)] transition-colors"
+        >
+          edit
+        </a>
         <DeleteScheduleButton
           action={deleteOne}
           label="delete"


### PR DESCRIPTION
## What
Adds a first version of **editing an existing schedule**. Until now, once a schedule was created you could only view its queue. This ships the **content-only** slice (agreed scope): edit **title, message, survey URL, link expiry, and reminders** in place — no re-timing, no history loss.

## How it works
- **`updateScheduleContentAction`** (`app/scheduled/actions.ts`), owner-or-member gated (via the existing `requireProjectAccess`):
  1. Positional-updates the config element(s) sharing the `id` in `Project.notifications` (`arrayFilters`).
  2. `updateMany` on **only future, unsent, non-reminder** occurrences: `status:"pending"` AND `scheduledFor > now` AND `isReminder != true`, setting `title/message/url/expireIn`.
  - This is **race-safe** vs the send worker (which atomically claims `status:"pending"` → `processing`), and **preserves sent history**. Already-materialised reminder occurrences are left as-is.
  - **Reminders** live only on the config and are materialised at send time, so editing them needs no occurrence backfill — future sends pick them up automatically.
- **Focused edit UI** at `app/dashboard/[studyId]/schedule/[notificationId]/edit/` — a server page that loads the config + a client `EditScheduleForm`. It reuses the create form's field labels (existing i18n keys) and visual tokens. **Cadence/recipients are shown read-only** with a note that timing/recipient editing is coming later, plus "changes apply to notifications not yet sent."
- **Entry points**: an `edit` link on both schedule-list views (`/scheduled`, `/dashboard/[studyId]/schedule`) and in the queue-detail header (gated by the existing `canEdit`).

## Explicitly out of scope (deferred, per plan)
- Editing **timing/cadence** and **start/stop** → needs a cron→form reverse-parser + a delete-future/regenerate-future cascade.
- Editing **recipients/groups**.

## Verification
- Full `next build` — types + compile pass; the new route registers.
- **Recommended before merge**: a manual E2E on staging — create a repeating schedule with a reminder, edit message/URL/reminder/expiry, and confirm future `pending` occurrences update while any `sent` occurrence is unchanged (the plan file details the exact checks). Server-action DB writes weren't runtime-exercised here (no DB in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
