### PR TITLE
Capture the schedule spec on create (edit foundation, sub-step 1/3)

### DIFF
--- a/nextapp/app/createenrollmentnotification/route.ts
+++ b/nextapp/app/createenrollmentnotification/route.ts
@@ -82,6 +82,7 @@ export async function POST(req: NextRequest) {
     timezone,
     useParticipantTimezone: !!useParticipantTimezone,
     reminders: reminders ?? [],
+    spec: (body as unknown as { spec?: unknown }).spec ?? null,
     created: new Date(),
   };
 

--- a/nextapp/app/createfixedindividualnotification/route.ts
+++ b/nextapp/app/createfixedindividualnotification/route.ts
@@ -90,7 +90,8 @@ export async function POST(req: NextRequest) {
     allCurrentParticipants: participantId !== null && participantId !== undefined && participantId.length === 0,
     allCurrentGroups: groups !== null && groups !== undefined && groups.length === 0,
     name: "One-time", windowInterval: interval,
-    scheduleInFuture, timezone, expireIn, useParticipantTimezone, reminders, yokedDesign: !!yokedDesign, created: new Date(),
+    scheduleInFuture, timezone, expireIn, useParticipantTimezone, reminders, yokedDesign: !!yokedDesign,
+    spec: (body as unknown as { spec?: unknown }).spec ?? null, created: new Date(),
   }));
 
   try {

--- a/nextapp/app/createindividualnotification/route.ts
+++ b/nextapp/app/createindividualnotification/route.ts
@@ -142,7 +142,7 @@ export async function POST(req: NextRequest) {
     start_after: int_start?.startAfter, stop_after: int_end?.stopAfter,
     start_next: int_start?.startNextDay, stop_next: int_end?.stopNextDay,
     start_event: int_start?.startEvent, stop_event: int_end?.stopEvent,
-    scheduleInFuture, timezone, expireIn, useParticipantTimezone, reminders, yokedDesign: !!yokedDesign, created: new Date(),
+    scheduleInFuture, timezone, expireIn, useParticipantTimezone, reminders, yokedDesign: !!yokedDesign, spec: (body as unknown as { spec?: unknown }).spec ?? null, created: new Date(),
     interval: iv,
   }));
 

--- a/nextapp/app/createintervalnotification/route.ts
+++ b/nextapp/app/createintervalnotification/route.ts
@@ -178,7 +178,7 @@ export async function POST(req: NextRequest) {
           start_next: int_start?.startNextDay, stop_next: int_end?.stopNextDay,
           start_event: int_start?.startEvent, stop_event: int_end?.stopEvent,
           scheduleInFuture, readable: { from: window.from && safeHuman(window.from), to: window.to && safeHuman(window.to) },
-          timezone, expireIn, useParticipantTimezone, reminders, yokedDesign: !!yokedDesign, created: new Date(),
+          timezone, expireIn, useParticipantTimezone, reminders, yokedDesign: !!yokedDesign, spec: (body as unknown as { spec?: unknown }).spec ?? null, created: new Date(),
         });
 
         if (groupIds) {
@@ -244,7 +244,7 @@ export async function POST(req: NextRequest) {
           start_next: int_start?.startNextDay, stop_next: int_end?.stopNextDay,
           start_event: int_start?.startEvent, stop_event: int_end?.stopEvent,
           scheduleInFuture, timezone, expireIn, useParticipantTimezone, reminders,
-          interval: iv, readable: { interval: safeHuman(iv) }, yokedDesign: !!yokedDesign, created: new Date(),
+          interval: iv, readable: { interval: safeHuman(iv) }, yokedDesign: !!yokedDesign, spec: (body as unknown as { spec?: unknown }).spec ?? null, created: new Date(),
         });
       }
 

--- a/nextapp/app/createschedulenotification/route.ts
+++ b/nextapp/app/createschedulenotification/route.ts
@@ -191,6 +191,7 @@ export async function POST(req: NextRequest) {
     expireIn,
     useParticipantTimezone,
     reminders,
+    spec: (body as unknown as { spec?: unknown }).spec ?? null,
     created: new Date(),
   };
 

--- a/nextapp/app/dashboard/[studyId]/schedule/new/NotificationForm.tsx
+++ b/nextapp/app/dashboard/[studyId]/schedule/new/NotificationForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useT } from "@/app/components/TranslationProvider";
+import { SPEC_VERSION, type ScheduleSpec } from "@/lib/scheduleSpec";
 
 interface Participant { id: string; username?: string }
 interface Group { id: string; name?: string }
@@ -498,7 +499,25 @@ export default function NotificationForm({ projectId, participants, groups, pres
       ? reminders.map((r) => ({ title: r.title, message: r.message, time: ((r.days * 24 * 60 + r.hours * 60 + r.minutes) * 60000) }))
       : [];
 
-    const commonFields = { projectId, title, message, url: url.trim(), timezone, useParticipantTimezone, expireIn, reminders: reminderList, scheduleInFuture: includeFuture, participants: participantsList, groups: groupsList, yokedDesign: includeGroups ? yokedDesign : false };
+    // Capture the researcher's original form inputs so the schedule can be
+    // re-hydrated for editing (and re-compiled) later. Only the hard-to-reverse
+    // cadence/recipient/timezone state is stored — content/expiry/reminders
+    // round-trip from plain config fields.
+    const spec: ScheduleSpec = {
+      specVersion: SPEC_VERSION,
+      timezone, useParticipantTimezone,
+      includeCurrent, includeFuture, includeGroups,
+      allCurrentParticipants, selectedParticipants, allCurrentGroups, selectedGroups, yokedDesign,
+      timeType, timepoints, timeWindows, repeatEvery, enrollmentDays, enrollmentHours, enrollmentMinutes,
+      dateType, specificDates, everyNDays, selectedWeekDays, selectedMonthDays,
+      monthType, selectedMonths,
+      startType, startHour, startMinute, startDay, startMonth, startYear,
+      startAfterDays, startAfterHours, startAfterMinutes, startEvent, startNextDay, startNextEvent,
+      stopType, stopHour, stopMinute, stopDay, stopMonth, stopYear,
+      stopAfterDays, stopAfterHours, stopAfterMinutes, stopEvent, stopNextDay, stopNextEvent,
+    };
+
+    const commonFields = { projectId, title, message, url: url.trim(), timezone, useParticipantTimezone, expireIn, reminders: reminderList, scheduleInFuture: includeFuture, participants: participantsList, groups: groupsList, yokedDesign: includeGroups ? yokedDesign : false, spec };
 
     setSubmitting(true);
     setStatus(null);

--- a/nextapp/lib/data/scheduled.ts
+++ b/nextapp/lib/data/scheduled.ts
@@ -2,6 +2,7 @@ import connectDB from "@/lib/db";
 import Project from "@/lib/models/project";
 import AgendaJob, { type IAgendaJob } from "@/lib/models/agendaJob";
 import PendingNotification, { type IPendingNotification } from "@/lib/models/pendingNotification";
+import type { ScheduleSpec } from "@/lib/scheduleSpec";
 import mongoose from "mongoose";
 
 export interface NotificationConfig {
@@ -40,6 +41,9 @@ export interface NotificationConfig {
   delay?: { days?: number; hours?: number; minutes?: number };
   expireIn?: number;
   reminders?: Array<{ title: string; message: string; time: number }>;
+  // Original form inputs, captured at create time so the schedule can be
+  // re-hydrated for editing / re-compiled later (see lib/scheduleSpec.ts).
+  spec?: ScheduleSpec | null;
 }
 
 export async function fetchScheduledNotifications(projectId: string): Promise<NotificationConfig[]> {

--- a/nextapp/lib/scheduleSpec.ts
+++ b/nextapp/lib/scheduleSpec.ts
@@ -1,0 +1,87 @@
+// ScheduleSpec — the researcher's ORIGINAL form inputs for a schedule, stored
+// verbatim on the notification config so the create form can be losslessly
+// re-hydrated for editing (and so schedules can be re-compiled if the
+// compilation logic changes).
+//
+// Scope: only the parts of the form that are hard/impossible to reverse from the
+// compiled config (cron strings + strategy objects) — recipients, time, date,
+// month, and the start/stop strategies, plus the timezone flags. Content
+// (title/message/url), link expiry and reminders are NOT included here: they are
+// already stored as plain top-level config fields and round-trip trivially, so
+// keeping them out of the spec avoids any drift with the content-edit form.
+//
+// Bump SPEC_VERSION whenever the shape changes in a way that needs migration;
+// hydration should tolerate missing/legacy fields via defaults.
+export const SPEC_VERSION = 1;
+
+export interface ScheduleSpecTimepoint { hour: number; minute: number }
+export interface ScheduleSpecTimeWindow {
+  hourStart: number; minuteStart: number; hourEnd: number; minuteEnd: number; distance: number; number: number;
+}
+export interface ScheduleSpecDate { day: number; month: number; year: number }
+
+export interface ScheduleSpec {
+  specVersion: number;
+
+  // Timezone
+  timezone: string;
+  useParticipantTimezone: boolean;
+
+  // Recipients
+  includeCurrent: boolean;
+  includeFuture: boolean;
+  includeGroups: boolean;
+  allCurrentParticipants: boolean;
+  selectedParticipants: string[];
+  allCurrentGroups: boolean;
+  selectedGroups: string[];
+  yokedDesign: boolean;
+
+  // Time
+  timeType: "specific" | "interval" | "repeat" | "enrollment";
+  timepoints: ScheduleSpecTimepoint[];
+  timeWindows: ScheduleSpecTimeWindow[];
+  repeatEvery: number;
+  enrollmentDays: number;
+  enrollmentHours: number;
+  enrollmentMinutes: number;
+
+  // Date
+  dateType: "specific" | "every" | "spec-week" | "spec-month";
+  specificDates: ScheduleSpecDate[];
+  everyNDays: number;
+  selectedWeekDays: string[];
+  selectedMonthDays: number[];
+
+  // Month
+  monthType: "every" | "specific";
+  selectedMonths: string[];
+
+  // Start strategy
+  startType: "specific" | "event" | "next";
+  startHour: number;
+  startMinute: number;
+  startDay: number;
+  startMonth: number;
+  startYear: number;
+  startAfterDays: number;
+  startAfterHours: number;
+  startAfterMinutes: number;
+  startEvent: "registration" | "now";
+  startNextDay: number;
+  startNextEvent: "registration" | "now";
+
+  // Stop strategy
+  stopType: "specific" | "event" | "next";
+  stopHour: number;
+  stopMinute: number;
+  stopDay: number;
+  stopMonth: number;
+  stopYear: number;
+  stopAfterDays: number;
+  stopAfterHours: number;
+  stopAfterMinutes: number;
+  stopEvent: "registration" | "now";
+  stopNextDay: number;
+  stopNextEvent: "registration" | "now";
+}


### PR DESCRIPTION
## What
**Sub-step 1 of 3** of the "make schedules editable" foundation: start **capturing the schedule spec** — the researcher's original form inputs — on every new schedule, stored verbatim on the config.

This is purely **additive**: it does not change the compiled cron/strategy fields, occurrence generation, or any existing behavior. It just begins recording the source-of-truth inputs so that future work can:
- **Re-hydrate the create form for editing** losslessly (no fragile cron→form reverse-parser).
- **Re-compile schedules** if the scheduling logic changes — e.g. the recent "every N days across months" fix would become a scripted recompile from spec instead of manual delete-and-recreate.

## Scope of the spec
Only the **hard-to-reverse** form state: recipients, time, date, month, and start/stop strategies, plus the timezone flags. **Content, link expiry and reminders are deliberately excluded** — they already round-trip trivially from plain top-level config fields, so leaving them out avoids any drift with the content-edit form.

## Changes
- **`nextapp/lib/scheduleSpec.ts`** (new): `ScheduleSpec` type + `SPEC_VERSION` (=1), with a `specVersion` field for future migration.
- **`NotificationForm.tsx`**: builds the spec from component state and includes it in the payload (`commonFields`). No change to how cron/strategy fields are built or posted.
- **All 5 create routes** persist `spec` on the pushed config object(s) — 6 config objects total, all covered (the `Project` model is `strict:false`, so no schema migration).
- **`NotificationConfig`** type gains an optional `spec` field.

## Verification
- Full `next build` — types + compile pass.
- Coverage check: every config object across the 5 create routes writes `spec` (verified by grep + build).
- No runtime behavior change to compilation or the queue.

## Next
- **Sub-step 2**: extract a shared `compileSpec(spec) → compiled fields`, so the spec becomes the single source of truth (create compiles *from* it). Behavior-preserving refactor of the production creation path — done as its own carefully-tested PR.
- **Sub-step 3**: timing/recipient editing built on spec re-hydration + recompile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
