### PR TITLE
Compile schedules from the spec (single source of truth, sub-step 2/3)

### DIFF
--- a/nextapp/app/dashboard/[studyId]/schedule/new/NotificationForm.tsx
+++ b/nextapp/app/dashboard/[studyId]/schedule/new/NotificationForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useT } from "@/app/components/TranslationProvider";
 import { SPEC_VERSION, type ScheduleSpec } from "@/lib/scheduleSpec";
+import { compileSpec, isInvalidRepeatDates } from "@/lib/compileSpec";
 
 interface Participant { id: string; username?: string }
 interface Group { id: string; name?: string }
@@ -24,8 +25,6 @@ const MONTH_VALUES   = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", 
 
 const now = new Date();
 const twoWeeksFromNow = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
-
-function getRandomSec() { return Math.floor(Math.random() * 60); }
 
 // ── Shared style tokens ────────────────────────────────────────────────────────
 
@@ -391,86 +390,6 @@ export default function NotificationForm({ projectId, participants, groups, pres
     setSelectedMonthDays((prev) => prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]);
   }
 
-  function buildTzIso(year: number, month: number, day: number, hour: number, minute: number): string {
-    const fmt = new Intl.DateTimeFormat("en-US", { timeZone: timezone, timeZoneName: "shortOffset" });
-    const candidate = new Date(Date.UTC(year, month, day, hour, minute));
-    const parts = fmt.formatToParts(candidate);
-    const offsetPart = parts.find((p) => p.type === "timeZoneName")?.value ?? "UTC+0";
-    const match = offsetPart.match(/([+-])(\d+)(?::(\d+))?/);
-    let offsetMs = 0;
-    if (match) {
-      const sign = match[1] === "+" ? 1 : -1;
-      offsetMs = sign * (parseInt(match[2]) * 60 + (parseInt(match[3] ?? "0"))) * 60000;
-    }
-    return new Date(candidate.getTime() - offsetMs).toISOString();
-  }
-
-  function addDuration(base: Date, d: { days?: number; hours?: number; minutes?: number }): Date {
-    const ms = ((d.days ?? 0) * 86400 + (d.hours ?? 0) * 3600 + (d.minutes ?? 0) * 60) * 1000;
-    return new Date(base.getTime() + ms);
-  }
-
-  function buildDayMonthCron(): string {
-    // "Every N days" is emitted as the open-ended step "*/N". The server anchors
-    // it to each recipient's actual window start (registration + offset) via
-    // patchStartDay — baking a fixed day-of-month here would wrongly anchor the
-    // cadence to the schedule's creation date instead.
-    if (dateType === "every") return everyNDays === 1 ? "*" : `*/${everyNDays}`;
-    if (dateType === "spec-week") return "*";
-    if (dateType === "spec-month") return selectedMonthDays.join(",") || "*";
-    return "*";
-  }
-  function buildDayWeekCron(): string {
-    return dateType === "spec-week" ? (selectedWeekDays.join(",") || "*") : "*";
-  }
-  function buildMonthCron(): string {
-    return monthType === "every" ? "*" : (selectedMonths.join(",") || "*");
-  }
-  function buildCronSchedules(): string[] {
-    return timepoints.map((tp) => `${getRandomSec()} ${tp.minute} ${tp.hour} ${buildDayMonthCron()} ${buildMonthCron()} ${buildDayWeekCron()}`);
-  }
-  function buildCronIntervals(): Array<{ from: string; to: string; number: number; distance: number }> {
-    const d = buildDayMonthCron(), w = buildDayWeekCron(), m = buildMonthCron();
-    return timeWindows.map((w2) => ({
-      from: `${getRandomSec()} ${w2.minuteStart} ${w2.hourStart} ${d} ${m} ${w}`,
-      to: `${getRandomSec()} ${w2.minuteEnd} ${w2.hourEnd} ${d} ${m} ${w}`,
-      number: w2.number,
-      distance: w2.distance,
-    }));
-  }
-
-  function buildStartingStrategy() {
-    if (startType === "specific") {
-      return { start: "specific", startMoment: buildTzIso(startYear, startMonth - 1, startDay, startHour, startMinute), startAfter: "", startEvent: "", startNextDay: "" };
-    }
-    if (startType === "event") {
-      const startMoment = startEvent === "now" ? addDuration(new Date(), { days: startAfterDays, hours: startAfterHours, minutes: startAfterMinutes }).toISOString() : "";
-      return { start: "event", startMoment, startAfter: { days: startAfterDays, hours: startAfterHours, minutes: startAfterMinutes }, startEvent, startNextDay: "" };
-    }
-    const startMoment = startNextEvent === "now"
-      ? (startNextDay == 1
-          ? addDuration(new Date(), { minutes: 1 }).toISOString()
-          : new Date(new Date().setHours(0, 0, 0, 0) + (startNextDay - 1) * 86400000 + Math.floor(Math.random() * 10) * 60000).toISOString())
-      : "";
-    return { start: "next", startMoment, startAfter: "", startEvent: startNextEvent, startNextDay };
-  }
-
-  function buildStoppingStrategy() {
-    if (stopType === "specific") {
-      return { stop: "specific", stopMoment: buildTzIso(stopYear, stopMonth - 1, stopDay, stopHour, stopMinute), stopAfter: "", stopEvent: "", stopNextDay: "" };
-    }
-    if (stopType === "event") {
-      const stopMoment = stopEvent === "now" ? addDuration(new Date(), { days: stopAfterDays, hours: stopAfterHours, minutes: stopAfterMinutes }).toISOString() : "";
-      return { stop: "event", stopMoment, stopAfter: { days: stopAfterDays, hours: stopAfterHours, minutes: stopAfterMinutes }, stopEvent, stopNextDay: "" };
-    }
-    const stopMoment = stopNextEvent === "now"
-      ? (stopNextDay == 1
-          ? addDuration(new Date(), { minutes: 1 }).toISOString()
-          : new Date(new Date().setHours(0, 0, 0, 0) + (stopNextDay - 1) * 86400000 + Math.floor(Math.random() * 10) * 60000).toISOString())
-      : "";
-    return { stop: "next", stopMoment, stopAfter: "", stopEvent: stopNextEvent, stopNextDay };
-  }
-
   async function handleSubmit() {
     if (!title.trim()) { alert(t("notificationForm.alertTitle")); return; }
     if (!message.trim()) { alert(t("notificationForm.alertMessage")); return; }
@@ -517,55 +436,17 @@ export default function NotificationForm({ projectId, participants, groups, pres
       stopAfterDays, stopAfterHours, stopAfterMinutes, stopEvent, stopNextDay, stopNextEvent,
     };
 
-    const commonFields = { projectId, title, message, url: url.trim(), timezone, useParticipantTimezone, expireIn, reminders: reminderList, scheduleInFuture: includeFuture, participants: participantsList, groups: groupsList, yokedDesign: includeGroups ? yokedDesign : false, spec };
+    // "repeat" cadence with "specific" one-off dates is not a valid combination.
+    if (isInvalidRepeatDates(spec)) { alert(t("notificationForm.alertRepeatDates")); return; }
 
     setSubmitting(true);
     setStatus(null);
 
     try {
-      let endpoint = "";
-      let payload: Record<string, unknown> = {};
-
-      if (timeType === "enrollment") {
-        endpoint = "/createenrollmentnotification";
-        payload = { ...commonFields, delay: { days: enrollmentDays, hours: enrollmentHours, minutes: enrollmentMinutes } };
-
-      } else if (timeType === "specific" && dateType === "specific") {
-        endpoint = "/createschedulenotification";
-        payload = { ...commonFields, timepoints, dates: specificDates };
-
-      } else if (timeType === "repeat") {
-        if (dateType === "specific") { alert(t("notificationForm.alertRepeatDates")); setSubmitting(false); return; }
-        const s = buildStartingStrategy(), e = buildStoppingStrategy();
-        const isRegBased = s.startEvent === "registration" || e.stopEvent === "registration";
-        const crons = [`${getRandomSec()} */${repeatEvery} * ${buildDayMonthCron()} ${buildMonthCron()} ${buildDayWeekCron()}`];
-        endpoint = isRegBased ? "/createindividualnotification" : "/createintervalnotification";
-        payload = { ...commonFields, interval: crons, int_start: s, int_end: e, randomize: false, participantId: participantsList };
-
-      } else if (timeType === "interval" && dateType === "specific") {
-        const fixedIntervals = timeWindows.map((w) =>
-          specificDates.map((d) => ({
-            from: buildTzIso(d.year, d.month - 1, d.day, w.hourStart, w.minuteStart),
-            to: buildTzIso(d.year, d.month - 1, d.day, w.hourEnd, w.minuteEnd),
-            number: w.number, distance: w.distance,
-          }))
-        ).flat();
-        endpoint = "/createfixedindividualnotification";
-        payload = { ...commonFields, intervals: fixedIntervals, participantId: participantsList };
-
-      } else {
-        const s = buildStartingStrategy(), e = buildStoppingStrategy();
-        const isRegBased = s.startEvent === "registration" || e.stopEvent === "registration";
-        if (timeType === "specific") {
-          const crons = buildCronSchedules();
-          endpoint = isRegBased ? "/createindividualnotification" : "/createintervalnotification";
-          payload = { ...commonFields, interval: crons, int_start: s, int_end: e, randomize: false, participantId: participantsList };
-        } else {
-          const cronWindows = buildCronIntervals();
-          endpoint = "/createintervalnotification";
-          payload = { ...commonFields, randomize: true, intervalWindows: cronWindows, int_start: s, int_end: e, participantId: participantsList };
-        }
-      }
+      // Compile the spec into the endpoint + timing/recipient payload; merge in
+      // the content fields (which are not part of the spec) and the raw spec.
+      const { endpoint, fields } = compileSpec(spec);
+      const payload = { projectId, title, message, url: url.trim(), expireIn, reminders: reminderList, spec, ...fields };
 
       const res = await fetch(endpoint, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
       const data = await res.json() as { warning?: string; redirect?: string; error?: string };

--- a/nextapp/lib/compileSpec.test.ts
+++ b/nextapp/lib/compileSpec.test.ts
@@ -1,0 +1,111 @@
+// Run with: node --experimental-strip-types lib/compileSpec.test.ts  (from nextapp/)
+import { compileSpec, isInvalidRepeatDates } from "./compileSpec.ts";
+import type { ScheduleSpec } from "./scheduleSpec.ts";
+
+let pass = 0, fail = 0;
+function eq(name: string, got: unknown, want: unknown) {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  console.log((ok ? "PASS " : "FAIL ") + name);
+  if (!ok) { console.log("   got :", JSON.stringify(got)); console.log("   want:", JSON.stringify(want)); fail++; } else pass++;
+}
+function ok(name: string, cond: boolean) { console.log((cond ? "PASS " : "FAIL ") + name); cond ? pass++ : fail++; }
+// Normalize the leading random-second field of a 6-field cron to "S".
+const norm = (c: string) => c.replace(/^\d+ /, "S ");
+
+function baseSpec(over: Partial<ScheduleSpec> = {}): ScheduleSpec {
+  return {
+    specVersion: 1,
+    timezone: "Europe/London", useParticipantTimezone: true,
+    includeCurrent: true, includeFuture: false, includeGroups: false,
+    allCurrentParticipants: true, selectedParticipants: [], allCurrentGroups: true, selectedGroups: [], yokedDesign: false,
+    timeType: "specific", timepoints: [{ hour: 17, minute: 0 }], timeWindows: [{ hourStart: 9, minuteStart: 0, hourEnd: 21, minuteEnd: 0, distance: 2700000, number: 5 }],
+    repeatEvery: 30, enrollmentDays: 0, enrollmentHours: 0, enrollmentMinutes: 0,
+    dateType: "every", specificDates: [{ day: 17, month: 7, year: 2026 }], everyNDays: 3, selectedWeekDays: [], selectedMonthDays: [],
+    monthType: "every", selectedMonths: [],
+    startType: "event", startHour: 9, startMinute: 0, startDay: 17, startMonth: 7, startYear: 2026,
+    startAfterDays: 0, startAfterHours: 0, startAfterMinutes: 0, startEvent: "registration", startNextDay: 1, startNextEvent: "registration",
+    stopType: "next", stopHour: 9, stopMinute: 0, stopDay: 15, stopMonth: 8, stopYear: 2026,
+    stopAfterDays: 0, stopAfterHours: 0, stopAfterMinutes: 0, stopEvent: "registration", stopNextDay: 29, stopNextEvent: "registration",
+    ...over,
+  };
+}
+
+// 1) User's case: reg-based, every 3 days at 17:00 -> individual route, cron */3 in day-of-month
+{
+  const r = compileSpec(baseSpec());
+  eq("1 endpoint (reg-based every-N-days)", r.endpoint, "/createindividualnotification");
+  eq("1 cron", norm((r.fields.interval as string[])[0]), "S 0 17 */3 * *");
+  eq("1 randomize", r.fields.randomize, false);
+  ok("1 int_start.startEvent=registration", (r.fields.int_start as { startEvent: string }).startEvent === "registration");
+  ok("1 int_end.stopNextDay=29", (r.fields.int_end as { stopNextDay: number }).stopNextDay === 29);
+  eq("1 participants (all current)", r.fields.participants, []);
+}
+
+// 2) Non-reg every-N-days (absolute start/stop) -> interval route
+{
+  const r = compileSpec(baseSpec({
+    startType: "specific", stopType: "specific",
+  }));
+  eq("2 endpoint (non-reg -> interval)", r.endpoint, "/createintervalnotification");
+  ok("2 int_start.start=specific", (r.fields.int_start as { start: string }).start === "specific");
+  ok("2 int_start.startMoment is ISO", /^2026-07-17T/.test((r.fields.int_start as { startMoment: string }).startMoment));
+}
+
+// 3) One-time specific dates -> schedule route
+{
+  const r = compileSpec(baseSpec({ timeType: "specific", dateType: "specific" }));
+  eq("3 endpoint (one-time)", r.endpoint, "/createschedulenotification");
+  eq("3 dates", r.fields.dates, [{ day: 17, month: 7, year: 2026 }]);
+  eq("3 timepoints", r.fields.timepoints, [{ hour: 17, minute: 0 }]);
+}
+
+// 4) Enrollment -> enrollment route with delay
+{
+  const r = compileSpec(baseSpec({ timeType: "enrollment", enrollmentDays: 2, enrollmentHours: 3 }));
+  eq("4 endpoint (enrollment)", r.endpoint, "/createenrollmentnotification");
+  eq("4 delay", r.fields.delay, { days: 2, hours: 3, minutes: 0 });
+}
+
+// 5) Random windows (timeType interval, non-specific dates) -> interval route, randomize true
+{
+  const r = compileSpec(baseSpec({ timeType: "interval", dateType: "every" }));
+  eq("5 endpoint (random windows)", r.endpoint, "/createintervalnotification");
+  eq("5 randomize", r.fields.randomize, true);
+  const w = (r.fields.intervalWindows as Array<{ from: string; to: string; number: number }>)[0];
+  eq("5 window.from cron", norm(w.from), "S 0 9 */3 * *");
+  eq("5 window.to cron", norm(w.to), "S 0 21 */3 * *");
+  eq("5 window.number", w.number, 5);
+}
+
+// 6) Fixed windows on specific dates -> fixed-individual route
+{
+  const r = compileSpec(baseSpec({ timeType: "interval", dateType: "specific" }));
+  eq("6 endpoint (fixed windows)", r.endpoint, "/createfixedindividualnotification");
+  const iv = (r.fields.intervals as Array<{ from: string; to: string; number: number }>)[0];
+  ok("6 interval.from ISO", /^2026-07-17T/.test(iv.from));
+  eq("6 interval.number", iv.number, 5);
+}
+
+// 7) Recipients: specific groups + yoked
+{
+  const r = compileSpec(baseSpec({
+    includeCurrent: false, includeGroups: true, allCurrentGroups: false, selectedGroups: ["g1", "g2"], yokedDesign: true,
+  }));
+  eq("7 participants (none)", r.fields.participants, null);
+  eq("7 groups", r.fields.groups, ["g1", "g2"]);
+  eq("7 yokedDesign", r.fields.yokedDesign, true);
+}
+
+// 8) Repeat minute-interval cron uses the MINUTE field, not day-of-month
+{
+  const r = compileSpec(baseSpec({ timeType: "repeat", dateType: "every", repeatEvery: 15, startType: "specific", stopType: "specific" }));
+  eq("8 endpoint (repeat non-reg)", r.endpoint, "/createintervalnotification");
+  eq("8 cron (minute interval)", norm((r.fields.interval as string[])[0]), "S */15 * */3 * *");
+}
+
+// 9) Invalid combo guard
+ok("9 isInvalidRepeatDates true for repeat+specific", isInvalidRepeatDates(baseSpec({ timeType: "repeat", dateType: "specific" })) === true);
+ok("9 isInvalidRepeatDates false otherwise", isInvalidRepeatDates(baseSpec()) === false);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/nextapp/lib/compileSpec.ts
+++ b/nextapp/lib/compileSpec.ts
@@ -1,0 +1,156 @@
+// compileSpec — the single source of truth for turning a ScheduleSpec (the
+// researcher's form inputs) into the API payload that a create route expects.
+//
+// This is a faithful extraction of the logic that previously lived inline in
+// NotificationForm.handleSubmit (buildCronSchedules / buildCronIntervals /
+// buildStartingStrategy / buildStoppingStrategy / buildDayMonthCron / etc.).
+// The form now builds a spec and calls compileSpec(spec); the edit flow can call
+// it too, so create and edit share one compiler and can never diverge.
+//
+// Pure except for getRandomSec (a per-submit delivery jitter, matching the old
+// behaviour) and the "now"/"next" start-stop strategies, which read the current
+// time — exactly as before. Content (title/message/url/expiry/reminders) and
+// projectId are NOT produced here; the caller merges those in.
+import type { ScheduleSpec } from "./scheduleSpec";
+
+function getRandomSec(): number {
+  return Math.floor(Math.random() * 60);
+}
+
+// A timezone-aware ISO string for a wall-clock date in the schedule timezone.
+function buildTzIso(timezone: string, year: number, month: number, day: number, hour: number, minute: number): string {
+  const fmt = new Intl.DateTimeFormat("en-US", { timeZone: timezone, timeZoneName: "shortOffset" });
+  const candidate = new Date(Date.UTC(year, month, day, hour, minute));
+  const parts = fmt.formatToParts(candidate);
+  const offsetPart = parts.find((p) => p.type === "timeZoneName")?.value ?? "UTC+0";
+  const match = offsetPart.match(/([+-])(\d+)(?::(\d+))?/);
+  let offsetMs = 0;
+  if (match) {
+    const sign = match[1] === "+" ? 1 : -1;
+    offsetMs = sign * (parseInt(match[2]) * 60 + parseInt(match[3] ?? "0")) * 60000;
+  }
+  return new Date(candidate.getTime() - offsetMs).toISOString();
+}
+
+function addDuration(base: Date, d: { days?: number; hours?: number; minutes?: number }): Date {
+  const ms = ((d.days ?? 0) * 86400 + (d.hours ?? 0) * 3600 + (d.minutes ?? 0) * 60) * 1000;
+  return new Date(base.getTime() + ms);
+}
+
+function buildDayMonthCron(spec: ScheduleSpec): string {
+  if (spec.dateType === "every") return spec.everyNDays === 1 ? "*" : `*/${spec.everyNDays}`;
+  if (spec.dateType === "spec-week") return "*";
+  if (spec.dateType === "spec-month") return spec.selectedMonthDays.join(",") || "*";
+  return "*";
+}
+function buildDayWeekCron(spec: ScheduleSpec): string {
+  return spec.dateType === "spec-week" ? (spec.selectedWeekDays.join(",") || "*") : "*";
+}
+function buildMonthCron(spec: ScheduleSpec): string {
+  return spec.monthType === "every" ? "*" : (spec.selectedMonths.join(",") || "*");
+}
+function buildCronSchedules(spec: ScheduleSpec): string[] {
+  return spec.timepoints.map((tp) => `${getRandomSec()} ${tp.minute} ${tp.hour} ${buildDayMonthCron(spec)} ${buildMonthCron(spec)} ${buildDayWeekCron(spec)}`);
+}
+function buildCronIntervals(spec: ScheduleSpec): Array<{ from: string; to: string; number: number; distance: number }> {
+  const d = buildDayMonthCron(spec), w = buildDayWeekCron(spec), m = buildMonthCron(spec);
+  return spec.timeWindows.map((w2) => ({
+    from: `${getRandomSec()} ${w2.minuteStart} ${w2.hourStart} ${d} ${m} ${w}`,
+    to: `${getRandomSec()} ${w2.minuteEnd} ${w2.hourEnd} ${d} ${m} ${w}`,
+    number: w2.number,
+    distance: w2.distance,
+  }));
+}
+
+function buildStartingStrategy(spec: ScheduleSpec) {
+  if (spec.startType === "specific") {
+    return { start: "specific", startMoment: buildTzIso(spec.timezone, spec.startYear, spec.startMonth - 1, spec.startDay, spec.startHour, spec.startMinute), startAfter: "", startEvent: "", startNextDay: "" };
+  }
+  if (spec.startType === "event") {
+    const startMoment = spec.startEvent === "now" ? addDuration(new Date(), { days: spec.startAfterDays, hours: spec.startAfterHours, minutes: spec.startAfterMinutes }).toISOString() : "";
+    return { start: "event", startMoment, startAfter: { days: spec.startAfterDays, hours: spec.startAfterHours, minutes: spec.startAfterMinutes }, startEvent: spec.startEvent, startNextDay: "" };
+  }
+  const startMoment = spec.startNextEvent === "now"
+    ? (spec.startNextDay == 1
+        ? addDuration(new Date(), { minutes: 1 }).toISOString()
+        : new Date(new Date().setHours(0, 0, 0, 0) + (spec.startNextDay - 1) * 86400000 + Math.floor(Math.random() * 10) * 60000).toISOString())
+    : "";
+  return { start: "next", startMoment, startAfter: "", startEvent: spec.startNextEvent, startNextDay: spec.startNextDay };
+}
+
+function buildStoppingStrategy(spec: ScheduleSpec) {
+  if (spec.stopType === "specific") {
+    return { stop: "specific", stopMoment: buildTzIso(spec.timezone, spec.stopYear, spec.stopMonth - 1, spec.stopDay, spec.stopHour, spec.stopMinute), stopAfter: "", stopEvent: "", stopNextDay: "" };
+  }
+  if (spec.stopType === "event") {
+    const stopMoment = spec.stopEvent === "now" ? addDuration(new Date(), { days: spec.stopAfterDays, hours: spec.stopAfterHours, minutes: spec.stopAfterMinutes }).toISOString() : "";
+    return { stop: "event", stopMoment, stopAfter: { days: spec.stopAfterDays, hours: spec.stopAfterHours, minutes: spec.stopAfterMinutes }, stopEvent: spec.stopEvent, stopNextDay: "" };
+  }
+  const stopMoment = spec.stopNextEvent === "now"
+    ? (spec.stopNextDay == 1
+        ? addDuration(new Date(), { minutes: 1 }).toISOString()
+        : new Date(new Date().setHours(0, 0, 0, 0) + (spec.stopNextDay - 1) * 86400000 + Math.floor(Math.random() * 10) * 60000).toISOString())
+    : "";
+  return { stop: "next", stopMoment, stopAfter: "", stopEvent: spec.stopNextEvent, stopNextDay: spec.stopNextDay };
+}
+
+export interface CompiledSchedule {
+  endpoint: string;
+  fields: Record<string, unknown>;
+}
+
+// True iff (timeType, dateType) is the one invalid combination the form rejects
+// with an alert ("repeat" cadence but "specific" one-off dates). Callers should
+// check this and surface the alert BEFORE compiling.
+export function isInvalidRepeatDates(spec: ScheduleSpec): boolean {
+  return spec.timeType === "repeat" && spec.dateType === "specific";
+}
+
+export function compileSpec(spec: ScheduleSpec): CompiledSchedule {
+  const participants = !spec.includeCurrent ? null : (spec.allCurrentParticipants ? [] : spec.selectedParticipants);
+  const groups = !spec.includeGroups ? null : (spec.allCurrentGroups ? [] : spec.selectedGroups);
+
+  const base = {
+    timezone: spec.timezone,
+    useParticipantTimezone: spec.useParticipantTimezone,
+    scheduleInFuture: spec.includeFuture,
+    participants,
+    groups,
+    yokedDesign: spec.includeGroups ? spec.yokedDesign : false,
+  };
+
+  if (spec.timeType === "enrollment") {
+    return { endpoint: "/createenrollmentnotification", fields: { ...base, delay: { days: spec.enrollmentDays, hours: spec.enrollmentHours, minutes: spec.enrollmentMinutes } } };
+  }
+
+  if (spec.timeType === "specific" && spec.dateType === "specific") {
+    return { endpoint: "/createschedulenotification", fields: { ...base, timepoints: spec.timepoints, dates: spec.specificDates } };
+  }
+
+  if (spec.timeType === "repeat") {
+    const s = buildStartingStrategy(spec), e = buildStoppingStrategy(spec);
+    const isRegBased = s.startEvent === "registration" || e.stopEvent === "registration";
+    const crons = [`${getRandomSec()} */${spec.repeatEvery} * ${buildDayMonthCron(spec)} ${buildMonthCron(spec)} ${buildDayWeekCron(spec)}`];
+    return { endpoint: isRegBased ? "/createindividualnotification" : "/createintervalnotification", fields: { ...base, interval: crons, int_start: s, int_end: e, randomize: false, participantId: participants } };
+  }
+
+  if (spec.timeType === "interval" && spec.dateType === "specific") {
+    const fixedIntervals = spec.timeWindows.map((w) =>
+      spec.specificDates.map((d) => ({
+        from: buildTzIso(spec.timezone, d.year, d.month - 1, d.day, w.hourStart, w.minuteStart),
+        to: buildTzIso(spec.timezone, d.year, d.month - 1, d.day, w.hourEnd, w.minuteEnd),
+        number: w.number, distance: w.distance,
+      }))
+    ).flat();
+    return { endpoint: "/createfixedindividualnotification", fields: { ...base, intervals: fixedIntervals, participantId: participants } };
+  }
+
+  const s = buildStartingStrategy(spec), e = buildStoppingStrategy(spec);
+  const isRegBased = s.startEvent === "registration" || e.stopEvent === "registration";
+  if (spec.timeType === "specific") {
+    const crons = buildCronSchedules(spec);
+    return { endpoint: isRegBased ? "/createindividualnotification" : "/createintervalnotification", fields: { ...base, interval: crons, int_start: s, int_end: e, randomize: false, participantId: participants } };
+  }
+  const cronWindows = buildCronIntervals(spec);
+  return { endpoint: "/createintervalnotification", fields: { ...base, randomize: true, intervalWindows: cronWindows, int_start: s, int_end: e, participantId: participants } };
+}


### PR DESCRIPTION
## What
**Sub-step 2 of 3** of the schedule-editing foundation: make the **spec the single source of truth** by extracting a shared `compileSpec(spec)`.

The compilation logic (cron building + start/stop strategies + endpoint selection) previously lived inline in `NotificationForm.handleSubmit`. It's now a pure module — `lib/compileSpec.ts`, `compileSpec(spec) → { endpoint, fields }`. The create form builds a `ScheduleSpec` and calls it; the upcoming **edit** flow will call the *same* function, so create and edit can never diverge, and schedules become **re-compilable from their spec**.

## Behavior-preserving
- `compileSpec` is a **faithful extraction** — the same `build*` functions, parameterised by `spec` instead of component state.
- The resulting API payload has the **same key set** as before: `compileSpec.fields` supplies timezone / recipients / branch-specific fields, and the form merges in content (title/message/url/expiry/reminders) + the raw spec. Routes read by key, so field order is irrelevant.
- The now-unused inline helpers were deleted (the form shrank ~126 lines).

## Tests
`lib/compileSpec.test.ts` — **29 assertions, all passing** (run with `node --experimental-strip-types lib/compileSpec.test.ts` from `nextapp/`; the repo has no test runner, and Node 22 strips types natively). Covers every branch:
- reg-based every-N-days → `/createindividualnotification`, cron `*/3` in day-of-month
- non-reg interval → `/createintervalnotification`
- one-time specific dates → `/createschedulenotification`
- enrollment → `/createenrollmentnotification` + delay
- random windows, fixed windows on specific dates
- recipient derivation (all-current / specific groups / yoked)
- the minute-interval `repeat` cron (uses the *minute* field, not day-of-month)
- the invalid `repeat`+`specific` guard

## ⚠️ Requires staging smoke-test before merge
This rewrites the production **schedule-creation** submit path, which can't be E2E-tested in this environment (no DB / no browser). The unit tests lock `compileSpec`'s output and `next build` type-checks everything, but please **create one schedule of each type on staging** (one-time, every-N-days reg-based + absolute, random window, fixed window, enrollment) and confirm they queue correctly before merging.

## Sequencing
Builds on sub-step 1 (#59, spec capture — already on master). Next: **sub-step 3**, timing/recipient editing via spec re-hydration + `compileSpec` recompile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
